### PR TITLE
Correct three-year-old typo in the Unity Daggerfall Tools menu

### DIFF
--- a/Scripts/Editor/LocationInstanceEditor.cs
+++ b/Scripts/Editor/LocationInstanceEditor.cs
@@ -16,7 +16,7 @@ namespace DaggerfallWorkshop.Loc
         Vector2 scrollPosition;
         string[] locationTypes = { "Smooth Terrain", "No Smoothing" };
 
-        [MenuItem("Daggerfall Tools/Location Intance Editor")]
+        [MenuItem("Daggerfall Tools/Location Instance Editor")]
         static void Init()
         {
             LocationInstanceEditor window = (LocationInstanceEditor)GetWindow(typeof(LocationInstanceEditor));


### PR DESCRIPTION
Changes "Intance" to "Instance"